### PR TITLE
Added addDefinition to entity definition repository

### DIFF
--- a/src/Isolate/UnitOfWork/Entity/Definition/Repository.php
+++ b/src/Isolate/UnitOfWork/Entity/Definition/Repository.php
@@ -14,6 +14,11 @@ use Isolate\UnitOfWork\Exception\RuntimeException;
 interface Repository
 {
     /**
+     * @param Definition $entityDefinition
+     */
+    public function addDefinition(Definition $entityDefinition);
+    
+    /**
      * @param $entity
      * @return boolean
      * 

--- a/src/Isolate/UnitOfWork/Entity/Definition/Repository.php
+++ b/src/Isolate/UnitOfWork/Entity/Definition/Repository.php
@@ -15,6 +15,8 @@ interface Repository
 {
     /**
      * @param Definition $entityDefinition
+     *
+     * @api
      */
     public function addDefinition(Definition $entityDefinition);
     

--- a/src/Isolate/UnitOfWork/Entity/Definition/Repository/InMemory.php
+++ b/src/Isolate/UnitOfWork/Entity/Definition/Repository/InMemory.php
@@ -32,7 +32,7 @@ final class InMemory implements Repository
                 throw new InvalidArgumentException("Each element in collection needs to be an instance of Isolate\\UnitOfWork\\Entity\\Definition");
             }
 
-            $this->entityDefinitions[(string) $definition->getClassName()] = $definition;
+            $this->addDefinition($definition);
         }
 
         $this->validateAssociations();

--- a/src/Isolate/UnitOfWork/Entity/Definition/Repository/InMemory.php
+++ b/src/Isolate/UnitOfWork/Entity/Definition/Repository/InMemory.php
@@ -39,6 +39,14 @@ final class InMemory implements Repository
     }
 
     /**
+     * @param Definition $entityDefinition
+     */
+    public function addDefinition(Definition $entityDefinition)
+    {
+        $this->entityDefinitions[(string) $entityDefinition->getClassName()] = $entityDefinition;
+    }
+
+    /**
      * @param $entity
      * @return bool
      * @throws InvalidArgumentException

--- a/tests/Isolate/UnitOfWork/Tests/UnitOfWorkTest.php
+++ b/tests/Isolate/UnitOfWork/Tests/UnitOfWorkTest.php
@@ -157,13 +157,29 @@ class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
         $this->assertSame("Norbert", $entity->getFirstName());
         $this->assertSame("Orzechowicz", $entity->getLastName());
     }
+    
+    function test_definition_registration_after_unit_of_work_is_created()
+    {
+        $definitions = new Definition\Repository\InMemory([]);
+        $unitOfWork = $this->createUnitOfWork($definitions);
+        $definitions->addDefinition($this->createFakeEntityDefinition());
+
+        $entity = new EntityFake();
+        $unitOfWork->register($entity);
+        $unitOfWork->commit();
+        $this->assertTrue($this->newCommandHandler->entityWasPersisted($entity));
+
+    }
 
     /**
      * @return UnitOfWork
      */
-    private function createUnitOfWork()
+    private function createUnitOfWork(Definition\Repository $definitions = null)
     {
-        $definitions = new Definition\Repository\InMemory([$this->createFakeEntityDefinition()]);
+        $definitions = (is_null($definitions)) 
+            ? new Definition\Repository\InMemory([$this->createFakeEntityDefinition()])
+            : $definitions;
+        
         $identifier = new EntityIdentifier($definitions);
 
         return new UnitOfWork(


### PR DESCRIPTION
Thanks to this simple change, entity definitions can be loaded dynamically. 
It means that you can load only those definitions that are used during request, it might improve performence, for example if you have large amount of entities. 
